### PR TITLE
Fixed typos (README and Limitations)

### DIFF
--- a/docs/Quick start.md
+++ b/docs/Quick start.md
@@ -31,7 +31,7 @@ Then start a static server to preview the site:
 $ python -m SimpleHTTPServer 3000
 ```
 
-By default, `REAME.md` will be load as the main page. If you want to set another file as main page, just set the `mainPage` option to the file name (without the `.md` extentsion):
+By default, `README.md` will be load as the main page. If you want to set another file as main page, just set the `mainPage` option to the file name (without the `.md` extentsion):
 
 ```diff
 const app = new Obsidian({

--- a/docs/limitations.md
+++ b/docs/limitations.md
@@ -1,6 +1,6 @@
-# Limtations
+# Limitations
 
-This project is in early development. There are some known limitaion but they would be resolved later. Since this is a open-source project, pull request is very welcome.
+This project is in early development. There are some known limitations but they would be resolved later. Since this is a open-source project, pull request is very welcome.
 
 ### notes in folder is not supported
 


### PR DESCRIPTION
I fixed a few typos:

- REAME -> README
- Limtations -> Limitations
- limitaion -> limitations

And renamed `docs/limitaions.md` to `docs/limitations.md`